### PR TITLE
Integrate deployed backend API client services

### DIFF
--- a/lib/constants/app_config.dart
+++ b/lib/constants/app_config.dart
@@ -3,7 +3,7 @@ class AppConfig {
 
   static const String apiBaseUrl = String.fromEnvironment(
     'ECHO_GEN_API_BASE',
-    defaultValue: 'http://localhost:8000/api/v1',
+    defaultValue: 'https://echo-gen-ai.vercel.app/api/v1',
   );
 
   static const Duration networkTimeout = Duration(seconds: 20);

--- a/lib/models/api_exception.dart
+++ b/lib/models/api_exception.dart
@@ -1,0 +1,9 @@
+class ApiException implements Exception {
+  ApiException(this.message, {this.statusCode});
+
+  final String message;
+  final int? statusCode;
+
+  @override
+  String toString() => 'ApiException(statusCode: $statusCode, message: $message)';
+}

--- a/lib/models/api_key_models.dart
+++ b/lib/models/api_key_models.dart
@@ -1,0 +1,86 @@
+class ApiKeyModel {
+  const ApiKeyModel({
+    required this.id,
+    required this.provider,
+    this.keyAlias,
+    required this.metadata,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  final String id;
+  final String provider;
+  final String? keyAlias;
+  final Map<String, dynamic> metadata;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+
+  factory ApiKeyModel.fromJson(Map<String, dynamic> json) => ApiKeyModel(
+        id: json['id'] as String,
+        provider: json['provider'] as String,
+        keyAlias: json['key_alias'] as String? ?? json['keyAlias'] as String?,
+        metadata: (json['metadata'] as Map<String, dynamic>?) ?? <String, dynamic>{},
+        createdAt: _parseDateTime(json['created_at'])!,
+        updatedAt: _parseDateTime(json['updated_at'])!,
+      );
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'id': id,
+        'provider': provider,
+        'key_alias': keyAlias,
+        'metadata': metadata,
+        'created_at': createdAt.toIso8601String(),
+        'updated_at': updatedAt.toIso8601String(),
+      };
+}
+
+class CreateApiKeyRequest {
+  const CreateApiKeyRequest({
+    required this.provider,
+    this.keyAlias,
+    required this.encryptedKey,
+    this.metadata = const <String, dynamic>{},
+  });
+
+  final String provider;
+  final String? keyAlias;
+  final String encryptedKey;
+  final Map<String, dynamic> metadata;
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'provider': provider,
+        if (keyAlias != null) 'key_alias': keyAlias,
+        'encrypted_key': encryptedKey,
+        if (metadata.isNotEmpty) 'metadata': metadata,
+      };
+}
+
+class UpdateApiKeyRequest {
+  const UpdateApiKeyRequest({
+    this.keyAlias,
+    this.encryptedKey,
+    this.metadata,
+  });
+
+  final String? keyAlias;
+  final String? encryptedKey;
+  final Map<String, dynamic>? metadata;
+
+  Map<String, dynamic> toJson() {
+    final payload = <String, dynamic>{};
+    if (keyAlias != null) payload['key_alias'] = keyAlias;
+    if (encryptedKey != null) payload['encrypted_key'] = encryptedKey;
+    if (metadata != null) payload['metadata'] = metadata;
+    return payload;
+  }
+}
+
+DateTime? _parseDateTime(dynamic value) {
+  if (value == null) {
+    return null;
+  }
+  if (value is DateTime) {
+    return value;
+  }
+  return DateTime.parse(value.toString()).toLocal();
+}

--- a/lib/models/auth_models.dart
+++ b/lib/models/auth_models.dart
@@ -1,14 +1,6 @@
 import 'dart:convert';
 
-class ApiException implements Exception {
-  ApiException(this.message, {this.statusCode});
-
-  final String message;
-  final int? statusCode;
-
-  @override
-  String toString() => 'ApiException(statusCode: $statusCode, message: $message)';
-}
+export 'api_exception.dart';
 
 class AuthSessionTokens {
   const AuthSessionTokens({

--- a/lib/models/content_models.dart
+++ b/lib/models/content_models.dart
@@ -1,0 +1,99 @@
+class ContentItemModel {
+  const ContentItemModel({
+    required this.id,
+    required this.userId,
+    required this.url,
+    required this.title,
+    required this.markdown,
+    required this.provider,
+    required this.metadata,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  final String id;
+  final String userId;
+  final String url;
+  final String title;
+  final String markdown;
+  final String provider;
+  final Map<String, dynamic> metadata;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+
+  factory ContentItemModel.fromJson(Map<String, dynamic> json) => ContentItemModel(
+        id: json['id'] as String,
+        userId: json['user_id'] as String? ?? json['userId'] as String? ?? '',
+        url: json['url'] as String,
+        title: json['title'] as String,
+        markdown: json['markdown'] as String,
+        provider: json['provider'] as String,
+        metadata: (json['metadata'] as Map<String, dynamic>?) ?? <String, dynamic>{},
+        createdAt: _parseDateTime(json['created_at'])!,
+        updatedAt: _parseDateTime(json['updated_at'])!,
+      );
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'id': id,
+        'user_id': userId,
+        'url': url,
+        'title': title,
+        'markdown': markdown,
+        'provider': provider,
+        'metadata': metadata,
+        'created_at': createdAt.toIso8601String(),
+        'updated_at': updatedAt.toIso8601String(),
+      };
+}
+
+class ContentListModel {
+  const ContentListModel({
+    required this.items,
+    required this.total,
+  });
+
+  final List<ContentItemModel> items;
+  final int total;
+
+  factory ContentListModel.fromJson(Map<String, dynamic> json) => ContentListModel(
+        items: (json['items'] as List<dynamic>)
+            .map((dynamic item) =>
+                ContentItemModel.fromJson(item as Map<String, dynamic>))
+            .toList(),
+        total: json['total'] as int,
+      );
+}
+
+class CreateContentRequest {
+  const CreateContentRequest({
+    required this.url,
+    required this.title,
+    required this.markdown,
+    required this.provider,
+    this.metadata = const <String, dynamic>{},
+  });
+
+  final String url;
+  final String title;
+  final String markdown;
+  final String provider;
+  final Map<String, dynamic> metadata;
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'url': url,
+        'title': title,
+        'markdown': markdown,
+        'provider': provider,
+        if (metadata.isNotEmpty) 'metadata': metadata,
+      };
+}
+
+DateTime? _parseDateTime(dynamic value) {
+  if (value == null) {
+    return null;
+  }
+  if (value is DateTime) {
+    return value;
+  }
+  return DateTime.parse(value.toString()).toLocal();
+}

--- a/lib/models/job_models.dart
+++ b/lib/models/job_models.dart
@@ -1,0 +1,86 @@
+class JobModel {
+  const JobModel({
+    required this.id,
+    required this.jobType,
+    required this.status,
+    required this.payload,
+    this.result,
+    this.error,
+    required this.createdAt,
+    required this.updatedAt,
+    this.startedAt,
+    this.finishedAt,
+  });
+
+  final String id;
+  final String jobType;
+  final String status;
+  final Map<String, dynamic> payload;
+  final Map<String, dynamic>? result;
+  final String? error;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+  final DateTime? startedAt;
+  final DateTime? finishedAt;
+
+  bool get isTerminal => status == 'succeeded' || status == 'failed';
+
+  factory JobModel.fromJson(Map<String, dynamic> json) {
+    final payload = json['payload'];
+    final result = json['result'];
+    return JobModel(
+      id: json['id'] as String,
+      jobType: json['job_type'] as String? ?? json['jobType'] as String? ?? '',
+      status: json['status'] as String,
+      payload: payload is Map<String, dynamic>
+          ? Map<String, dynamic>.from(payload)
+          : <String, dynamic>{},
+      result: result is Map<String, dynamic>
+          ? Map<String, dynamic>.from(result)
+          : null,
+      error: json['error'] as String?,
+      createdAt: _parseDateTime(json['created_at'])!,
+      updatedAt: _parseDateTime(json['updated_at'])!,
+      startedAt: _parseDateTime(json['started_at'] ?? json['startedAt']),
+      finishedAt: _parseDateTime(json['finished_at'] ?? json['finishedAt']),
+    );
+  }
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'id': id,
+        'job_type': jobType,
+        'status': status,
+        'payload': payload,
+        if (result != null) 'result': result,
+        if (error != null) 'error': error,
+        'created_at': createdAt.toIso8601String(),
+        'updated_at': updatedAt.toIso8601String(),
+        'started_at': startedAt?.toIso8601String(),
+        'finished_at': finishedAt?.toIso8601String(),
+      };
+}
+
+class CreateJobRequest {
+  const CreateJobRequest({
+    required this.jobType,
+    this.payload = const <String, dynamic>{},
+  });
+
+  final String jobType;
+  final Map<String, dynamic> payload;
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'job_type': jobType,
+        if (payload.isNotEmpty) 'payload': payload,
+      };
+}
+
+DateTime? _parseDateTime(dynamic value) {
+  if (value == null || value == '') {
+    return null;
+  }
+  if (value is DateTime) {
+    return value;
+  }
+  return DateTime.parse(value.toString()).toLocal();
+}

--- a/lib/models/podcast_models.dart
+++ b/lib/models/podcast_models.dart
@@ -1,0 +1,119 @@
+import 'script_models.dart';
+
+class PodcastModel {
+  const PodcastModel({
+    required this.id,
+    required this.userId,
+    required this.scriptId,
+    required this.audioUrl,
+    this.coverArtUrl,
+    this.durationSeconds,
+    required this.metadata,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  final String id;
+  final String userId;
+  final String scriptId;
+  final String audioUrl;
+  final String? coverArtUrl;
+  final int? durationSeconds;
+  final Map<String, dynamic> metadata;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+
+  factory PodcastModel.fromJson(Map<String, dynamic> json) => PodcastModel(
+        id: json['id'] as String,
+        userId: json['user_id'] as String? ?? json['userId'] as String? ?? '',
+        scriptId: json['script_id'] as String? ?? json['scriptId'] as String? ?? '',
+        audioUrl: json['audio_url'] as String? ?? json['audioUrl'] as String? ?? '',
+        coverArtUrl:
+            json['cover_art_url'] as String? ?? json['coverArtUrl'] as String?,
+        durationSeconds: (json['duration_seconds'] as num?)?.toInt() ??
+            (json['durationSeconds'] as num?)?.toInt(),
+        metadata: (json['metadata'] as Map<String, dynamic>?) ?? <String, dynamic>{},
+        createdAt: _parseDateTime(json['created_at'])!,
+        updatedAt: _parseDateTime(json['updated_at'])!,
+      );
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'id': id,
+        'user_id': userId,
+        'script_id': scriptId,
+        'audio_url': audioUrl,
+        'cover_art_url': coverArtUrl,
+        'duration_seconds': durationSeconds,
+        'metadata': metadata,
+        'created_at': createdAt.toIso8601String(),
+        'updated_at': updatedAt.toIso8601String(),
+      };
+}
+
+class PodcastDetailModel extends PodcastModel {
+  const PodcastDetailModel({
+    required super.id,
+    required super.userId,
+    required super.scriptId,
+    required super.audioUrl,
+    super.coverArtUrl,
+    super.durationSeconds,
+    required super.metadata,
+    required super.createdAt,
+    required super.updatedAt,
+    required this.script,
+  });
+
+  final ScriptModel script;
+
+  factory PodcastDetailModel.fromJson(Map<String, dynamic> json) =>
+      PodcastDetailModel(
+        id: json['id'] as String,
+        userId: json['user_id'] as String? ?? json['userId'] as String? ?? '',
+        scriptId: json['script_id'] as String? ?? json['scriptId'] as String? ?? '',
+        audioUrl: json['audio_url'] as String? ?? json['audioUrl'] as String? ?? '',
+        coverArtUrl:
+            json['cover_art_url'] as String? ?? json['coverArtUrl'] as String?,
+        durationSeconds: (json['duration_seconds'] as num?)?.toInt() ??
+            (json['durationSeconds'] as num?)?.toInt(),
+        metadata: (json['metadata'] as Map<String, dynamic>?) ?? <String, dynamic>{},
+        createdAt: _parseDateTime(json['created_at'])!,
+        updatedAt: _parseDateTime(json['updated_at'])!,
+        script: ScriptModel.fromJson(json['script'] as Map<String, dynamic>),
+      );
+}
+
+class CreatePodcastRequest {
+  const CreatePodcastRequest({
+    required this.scriptId,
+    required this.audioStoragePath,
+    this.coverArtStoragePath,
+    this.durationSeconds,
+    this.metadata = const <String, dynamic>{},
+  });
+
+  final String scriptId;
+  final String audioStoragePath;
+  final String? coverArtStoragePath;
+  final int? durationSeconds;
+  final Map<String, dynamic> metadata;
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'script_id': scriptId,
+        'audio_storage_path': audioStoragePath,
+        if (coverArtStoragePath != null)
+          'cover_art_storage_path': coverArtStoragePath,
+        if (durationSeconds != null) 'duration_seconds': durationSeconds,
+        if (metadata.isNotEmpty) 'metadata': metadata,
+      };
+}
+
+DateTime? _parseDateTime(dynamic value) {
+  if (value == null) {
+    return null;
+  }
+  if (value is DateTime) {
+    return value;
+  }
+  return DateTime.parse(value.toString()).toLocal();
+}

--- a/lib/models/script_models.dart
+++ b/lib/models/script_models.dart
@@ -1,0 +1,123 @@
+class ScriptSegmentModel {
+  const ScriptSegmentModel({
+    required this.speaker,
+    required this.content,
+    this.startTime,
+    this.endTime,
+  });
+
+  final String speaker;
+  final String content;
+  final double? startTime;
+  final double? endTime;
+
+  factory ScriptSegmentModel.fromJson(Map<String, dynamic> json) =>
+      ScriptSegmentModel(
+        speaker: json['speaker'] as String,
+        content: json['content'] as String,
+        startTime: (json['start_time'] as num?)?.toDouble() ??
+            (json['startTime'] as num?)?.toDouble(),
+        endTime: (json['end_time'] as num?)?.toDouble() ??
+            (json['endTime'] as num?)?.toDouble(),
+      );
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'speaker': speaker,
+        'content': content,
+        if (startTime != null) 'start_time': startTime,
+        if (endTime != null) 'end_time': endTime,
+      };
+}
+
+class ScriptModel {
+  const ScriptModel({
+    required this.id,
+    required this.userId,
+    this.sourceContentId,
+    required this.prompt,
+    required this.model,
+    required this.language,
+    required this.segments,
+    required this.metadata,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  final String id;
+  final String userId;
+  final String? sourceContentId;
+  final String prompt;
+  final String model;
+  final String language;
+  final List<ScriptSegmentModel> segments;
+  final Map<String, dynamic> metadata;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+
+  factory ScriptModel.fromJson(Map<String, dynamic> json) => ScriptModel(
+        id: json['id'] as String,
+        userId: json['user_id'] as String? ?? json['userId'] as String? ?? '',
+        sourceContentId:
+            json['source_content_id'] as String? ?? json['sourceContentId'] as String?,
+        prompt: json['prompt'] as String,
+        model: json['model'] as String,
+        language: json['language'] as String,
+        segments: (json['segments'] as List<dynamic>)
+            .map((dynamic segment) =>
+                ScriptSegmentModel.fromJson(segment as Map<String, dynamic>))
+            .toList(),
+        metadata: (json['metadata'] as Map<String, dynamic>?) ?? <String, dynamic>{},
+        createdAt: _parseDateTime(json['created_at'])!,
+        updatedAt: _parseDateTime(json['updated_at'])!,
+      );
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'id': id,
+        'user_id': userId,
+        'source_content_id': sourceContentId,
+        'prompt': prompt,
+        'model': model,
+        'language': language,
+        'segments': segments.map((segment) => segment.toJson()).toList(),
+        'metadata': metadata,
+        'created_at': createdAt.toIso8601String(),
+        'updated_at': updatedAt.toIso8601String(),
+      };
+}
+
+class CreateScriptRequest {
+  const CreateScriptRequest({
+    this.sourceContentId,
+    required this.prompt,
+    required this.model,
+    this.language = 'en',
+    required this.segments,
+    this.metadata = const <String, dynamic>{},
+  });
+
+  final String? sourceContentId;
+  final String prompt;
+  final String model;
+  final String language;
+  final List<ScriptSegmentModel> segments;
+  final Map<String, dynamic> metadata;
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        if (sourceContentId != null) 'source_content_id': sourceContentId,
+        'prompt': prompt,
+        'model': model,
+        'language': language,
+        'segments': segments.map((segment) => segment.toJson()).toList(),
+        if (metadata.isNotEmpty) 'metadata': metadata,
+      };
+}
+
+DateTime? _parseDateTime(dynamic value) {
+  if (value == null) {
+    return null;
+  }
+  if (value is DateTime) {
+    return value;
+  }
+  return DateTime.parse(value.toString()).toLocal();
+}

--- a/lib/services/api_keys_api_service.dart
+++ b/lib/services/api_keys_api_service.dart
@@ -1,0 +1,57 @@
+import '../models/api_key_models.dart';
+import 'backend_api_client.dart';
+
+class ApiKeysApiService {
+  ApiKeysApiService({BackendApiClient? apiClient})
+      : _client = apiClient ?? BackendApiClient();
+
+  final BackendApiClient _client;
+
+  Future<ApiKeyModel> createKey({
+    required String token,
+    required CreateApiKeyRequest request,
+  }) async {
+    final response = await _client.post(
+      '/api-keys',
+      token: token,
+      body: request.toJson(),
+    ) as Map<String, dynamic>;
+
+    return ApiKeyModel.fromJson(response);
+  }
+
+  Future<List<ApiKeyModel>> listKeys(String token) async {
+    final response = await _client.get(
+      '/api-keys',
+      token: token,
+    ) as List<dynamic>;
+
+    return response
+        .map((dynamic item) => ApiKeyModel.fromJson(item as Map<String, dynamic>))
+        .toList();
+  }
+
+  Future<ApiKeyModel> updateKey({
+    required String token,
+    required String keyId,
+    required UpdateApiKeyRequest request,
+  }) async {
+    final response = await _client.patch(
+      '/api-keys/$keyId',
+      token: token,
+      body: request.toJson(),
+    ) as Map<String, dynamic>;
+
+    return ApiKeyModel.fromJson(response);
+  }
+
+  Future<void> deleteKey({
+    required String token,
+    required String keyId,
+  }) async {
+    await _client.delete(
+      '/api-keys/$keyId',
+      token: token,
+    );
+  }
+}

--- a/lib/services/auth_api_service.dart
+++ b/lib/services/auth_api_service.dart
@@ -1,48 +1,28 @@
-import 'dart:convert';
-
 import 'package:http/http.dart' as http;
 
-import '../constants/app_config.dart';
 import '../models/auth_models.dart';
+import 'backend_api_client.dart';
 
 class AuthApiService {
-  AuthApiService({http.Client? client}) : _client = client ?? http.Client();
+  AuthApiService({BackendApiClient? apiClient, http.Client? httpClient})
+      : _client = apiClient ?? BackendApiClient(httpClient: httpClient);
 
-  final http.Client _client;
-
-  Uri _buildUri(String path) => Uri.parse('${AppConfig.apiBaseUrl}$path');
-
-  Map<String, String> _jsonHeaders({String? token}) {
-    final headers = <String, String>{
-      'Content-Type': 'application/json',
-      'Accept': 'application/json',
-    };
-    if (token != null) {
-      headers['Authorization'] = 'Bearer $token';
-    }
-    return headers;
-  }
+  final BackendApiClient _client;
 
   Future<AuthResponseModel> signIn({
     required String identifier,
     required String password,
   }) async {
-    final response = await _client
-        .post(
-          _buildUri('/auth/signin'),
-          headers: _jsonHeaders(),
-          body: json.encode({
-            'method': 'email',
-            'email': identifier,
-            'password': password,
-          }),
-        )
-        .timeout(AppConfig.networkTimeout);
+    final response = await _client.post(
+      '/auth/signin',
+      body: {
+        'method': 'email',
+        'email': identifier,
+        'password': password,
+      },
+    ) as Map<String, dynamic>;
 
-    final Map<String, dynamic> body = _decodeBody(response);
-    _throwIfError(response, body);
-
-    return AuthResponseModel.fromJson(body);
+    return AuthResponseModel.fromJson(response);
   }
 
   Future<AuthResponseModel> signUp({
@@ -50,51 +30,35 @@ class AuthApiService {
     required String password,
     required String? fullName,
   }) async {
-    final response = await _client
-        .post(
-          _buildUri('/auth/signup'),
-          headers: _jsonHeaders(),
-          body: json.encode({
-            'method': 'email',
-            'email': email,
-            'password': password,
-            if (fullName != null && fullName.isNotEmpty) 'fullName': fullName,
-          }),
-        )
-        .timeout(AppConfig.networkTimeout);
+    final response = await _client.post(
+      '/auth/signup',
+      body: {
+        'method': 'email',
+        'email': email,
+        'password': password,
+        if (fullName != null && fullName.isNotEmpty) 'fullName': fullName,
+      },
+    ) as Map<String, dynamic>;
 
-    final Map<String, dynamic> body = _decodeBody(response);
-    _throwIfError(response, body);
-
-    return AuthResponseModel.fromJson(body);
+    return AuthResponseModel.fromJson(response);
   }
 
   Future<UserProfileModel> fetchCurrentUser(String token) async {
-    final response = await _client
-        .get(
-          _buildUri('/auth/me'),
-          headers: _jsonHeaders(token: token),
-        )
-        .timeout(AppConfig.networkTimeout);
+    final response = await _client.get(
+      '/auth/me',
+      token: token,
+    ) as Map<String, dynamic>;
 
-    final Map<String, dynamic> body = _decodeBody(response);
-    _throwIfError(response, body);
-
-    return UserProfileModel.fromJson(body);
+    return UserProfileModel.fromJson(response);
   }
 
   Future<UserProfileModel> refreshUser(String userId, String token) async {
-    final response = await _client
-        .get(
-          _buildUri('/auth/users/$userId'),
-          headers: _jsonHeaders(token: token),
-        )
-        .timeout(AppConfig.networkTimeout);
+    final response = await _client.get(
+      '/auth/users/$userId',
+      token: token,
+    ) as Map<String, dynamic>;
 
-    final Map<String, dynamic> body = _decodeBody(response);
-    _throwIfError(response, body);
-
-    return UserProfileModel.fromJson(body);
+    return UserProfileModel.fromJson(response);
   }
 
   Future<UserProfileModel> updateProfile({
@@ -110,109 +74,61 @@ class AuthApiService {
     if (bio != null) payload['bio'] = bio;
     if (preferences != null) payload['preferences'] = preferences;
 
-    final response = await _client
-        .patch(
-          _buildUri('/auth/profile'),
-          headers: _jsonHeaders(token: token),
-          body: json.encode(payload),
-        )
-        .timeout(AppConfig.networkTimeout);
+    final response = await _client.patch(
+      '/auth/profile',
+      token: token,
+      body: payload,
+    ) as Map<String, dynamic>;
 
-    final Map<String, dynamic> body = _decodeBody(response);
-    _throwIfError(response, body);
-
-    return UserProfileModel.fromJson(body);
+    return UserProfileModel.fromJson(response);
   }
 
   Future<UserProfileModel> submitOnboarding({
     required String token,
     required List<OnboardingAnswerModel> responses,
   }) async {
-    final response = await _client
-        .post(
-          _buildUri('/auth/onboarding'),
-          headers: _jsonHeaders(token: token),
-          body: json.encode({
-            'responses': responses.map((e) => e.toJson()).toList(),
-          }),
-        )
-        .timeout(AppConfig.networkTimeout);
+    final response = await _client.post(
+      '/auth/onboarding',
+      token: token,
+      body: {
+        'responses': responses.map((e) => e.toJson()).toList(),
+      },
+    ) as Map<String, dynamic>;
 
-    final Map<String, dynamic> body = _decodeBody(response);
-    _throwIfError(response, body);
-
-    return UserProfileModel.fromJson(body);
+    return UserProfileModel.fromJson(response);
   }
 
   Future<AccountDeletionStatusModel> scheduleAccountDeletion(String token) async {
-    final response = await _client
-        .delete(
-          _buildUri('/auth/account'),
-          headers: _jsonHeaders(token: token),
-        )
-        .timeout(AppConfig.networkTimeout);
+    final response = await _client.delete(
+      '/auth/account',
+      token: token,
+    ) as Map<String, dynamic>;
 
-    final Map<String, dynamic> body = _decodeBody(response);
-    _throwIfError(response, body);
-
-    return AccountDeletionStatusModel.fromJson(body);
+    return AccountDeletionStatusModel.fromJson(response);
   }
 
   Future<AccountDeletionStatusModel?> cancelAccountDeletion(String token) async {
-    final response = await _client
-        .post(
-          _buildUri('/auth/account/cancel'),
-          headers: _jsonHeaders(token: token),
-        )
-        .timeout(AppConfig.networkTimeout);
+    final response = await _client.post(
+      '/auth/account/cancel',
+      token: token,
+    );
 
-    if (response.statusCode == 204 || response.body.isEmpty) {
+    if (response == null) {
       return null;
     }
 
-    final Map<String, dynamic> body = _decodeBody(response);
-    _throwIfError(response, body);
-
-    if (body.isEmpty) {
+    final data = response as Map<String, dynamic>;
+    if (data.isEmpty) {
       return null;
     }
 
-    return AccountDeletionStatusModel.fromJson(body);
+    return AccountDeletionStatusModel.fromJson(data);
   }
 
   Future<void> signOut(String token) async {
-    final response = await _client
-        .post(
-          _buildUri('/auth/signout'),
-          headers: _jsonHeaders(token: token),
-        )
-        .timeout(AppConfig.networkTimeout);
-
-    if (response.statusCode >= 400) {
-      final Map<String, dynamic> body = _decodeBody(response);
-      _throwIfError(response, body);
-    }
-  }
-
-  Map<String, dynamic> _decodeBody(http.Response response) {
-    if (response.body.isEmpty) {
-      return <String, dynamic>{};
-    }
-    try {
-      final dynamic decoded = json.decode(response.body);
-      if (decoded is Map<String, dynamic>) {
-        return decoded;
-      }
-      return <String, dynamic>{'data': decoded};
-    } catch (_) {
-      return <String, dynamic>{};
-    }
-  }
-
-  void _throwIfError(http.Response response, Map<String, dynamic> body) {
-    if (response.statusCode >= 400) {
-      final message = body['detail'] ?? body['message'] ?? 'Request failed';
-      throw ApiException(message.toString(), statusCode: response.statusCode);
-    }
+    await _client.post(
+      '/auth/signout',
+      token: token,
+    );
   }
 }

--- a/lib/services/backend_api_client.dart
+++ b/lib/services/backend_api_client.dart
@@ -1,0 +1,128 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+import '../constants/app_config.dart';
+import '../models/api_exception.dart';
+
+class BackendApiClient {
+  BackendApiClient({http.Client? httpClient})
+      : _httpClient = httpClient ?? http.Client();
+
+  final http.Client _httpClient;
+
+  Uri _buildUri(String path, [Map<String, dynamic>? queryParameters]) {
+    final uri = Uri.parse('${AppConfig.apiBaseUrl}$path');
+    if (queryParameters == null || queryParameters.isEmpty) {
+      return uri;
+    }
+    final filtered = <String, String>{};
+    queryParameters.forEach((key, value) {
+      if (value == null) return;
+      filtered[key] = value.toString();
+    });
+    return uri.replace(queryParameters: filtered);
+  }
+
+  Map<String, String> _jsonHeaders({String? token}) {
+    final headers = <String, String>{
+      'Content-Type': 'application/json',
+      'Accept': 'application/json',
+    };
+    if (token != null && token.isNotEmpty) {
+      headers['Authorization'] = 'Bearer $token';
+    }
+    return headers;
+  }
+
+  Future<dynamic> get(
+    String path, {
+    String? token,
+    Map<String, dynamic>? queryParameters,
+  }) {
+    return _send(() {
+      final uri = _buildUri(path, queryParameters);
+      return _httpClient.get(uri, headers: _jsonHeaders(token: token));
+    });
+  }
+
+  Future<dynamic> post(
+    String path, {
+    String? token,
+    Object? body,
+    Map<String, dynamic>? queryParameters,
+  }) {
+    return _send(() {
+      final uri = _buildUri(path, queryParameters);
+      return _httpClient.post(
+        uri,
+        headers: _jsonHeaders(token: token),
+        body: body == null ? null : json.encode(body),
+      );
+    });
+  }
+
+  Future<dynamic> patch(
+    String path, {
+    String? token,
+    Object? body,
+    Map<String, dynamic>? queryParameters,
+  }) {
+    return _send(() {
+      final uri = _buildUri(path, queryParameters);
+      return _httpClient.patch(
+        uri,
+        headers: _jsonHeaders(token: token),
+        body: body == null ? null : json.encode(body),
+      );
+    });
+  }
+
+  Future<dynamic> delete(
+    String path, {
+    String? token,
+    Object? body,
+    Map<String, dynamic>? queryParameters,
+  }) {
+    return _send(() {
+      final uri = _buildUri(path, queryParameters);
+      return _httpClient.delete(
+        uri,
+        headers: _jsonHeaders(token: token),
+        body: body == null ? null : json.encode(body),
+      );
+    });
+  }
+
+  Future<dynamic> _send(Future<http.Response> Function() request) async {
+    final response = await request().timeout(AppConfig.networkTimeout);
+    final dynamic data = _decodeBody(response);
+    _throwIfError(response, data);
+    return data;
+  }
+
+  dynamic _decodeBody(http.Response response) {
+    if (response.body.isEmpty) {
+      return null;
+    }
+    try {
+      return json.decode(response.body);
+    } catch (_) {
+      return response.body;
+    }
+  }
+
+  void _throwIfError(http.Response response, dynamic body) {
+    if (response.statusCode < 400) {
+      return;
+    }
+    if (body is Map<String, dynamic>) {
+      final message = body['detail'] ?? body['message'] ?? 'Request failed';
+      throw ApiException(message.toString(), statusCode: response.statusCode);
+    }
+    if (body is String && body.isNotEmpty) {
+      throw ApiException(body, statusCode: response.statusCode);
+    }
+    throw ApiException('Request failed', statusCode: response.statusCode);
+  }
+}

--- a/lib/services/content_api_service.dart
+++ b/lib/services/content_api_service.dart
@@ -1,0 +1,61 @@
+import '../models/content_models.dart';
+import 'backend_api_client.dart';
+
+class ContentApiService {
+  ContentApiService({BackendApiClient? apiClient})
+      : _client = apiClient ?? BackendApiClient();
+
+  final BackendApiClient _client;
+
+  Future<ContentItemModel> createContent({
+    required String token,
+    required CreateContentRequest request,
+  }) async {
+    final response = await _client.post(
+      '/content',
+      token: token,
+      body: request.toJson(),
+    ) as Map<String, dynamic>;
+
+    return ContentItemModel.fromJson(response);
+  }
+
+  Future<ContentListModel> listContent({
+    required String token,
+    int limit = 20,
+    int offset = 0,
+  }) async {
+    final response = await _client.get(
+      '/content',
+      token: token,
+      queryParameters: {
+        'limit': limit,
+        'offset': offset,
+      },
+    ) as Map<String, dynamic>;
+
+    return ContentListModel.fromJson(response);
+  }
+
+  Future<ContentItemModel> getContent({
+    required String token,
+    required String contentId,
+  }) async {
+    final response = await _client.get(
+      '/content/$contentId',
+      token: token,
+    ) as Map<String, dynamic>;
+
+    return ContentItemModel.fromJson(response);
+  }
+
+  Future<void> deleteContent({
+    required String token,
+    required String contentId,
+  }) async {
+    await _client.delete(
+      '/content/$contentId',
+      token: token,
+    );
+  }
+}

--- a/lib/services/jobs_api_service.dart
+++ b/lib/services/jobs_api_service.dart
@@ -1,0 +1,53 @@
+import '../models/job_models.dart';
+import 'backend_api_client.dart';
+
+class JobsApiService {
+  JobsApiService({BackendApiClient? apiClient})
+      : _client = apiClient ?? BackendApiClient();
+
+  final BackendApiClient _client;
+
+  Future<JobModel> enqueueJob({
+    required String token,
+    required CreateJobRequest request,
+  }) async {
+    final response = await _client.post(
+      '/jobs',
+      token: token,
+      body: request.toJson(),
+    ) as Map<String, dynamic>;
+
+    return JobModel.fromJson(response);
+  }
+
+  Future<List<JobModel>> listJobs({
+    required String token,
+    int limit = 20,
+    int offset = 0,
+  }) async {
+    final response = await _client.get(
+      '/jobs',
+      token: token,
+      queryParameters: {
+        'limit': limit,
+        'offset': offset,
+      },
+    ) as List<dynamic>;
+
+    return response
+        .map((dynamic item) => JobModel.fromJson(item as Map<String, dynamic>))
+        .toList();
+  }
+
+  Future<JobModel> getJob({
+    required String token,
+    required String jobId,
+  }) async {
+    final response = await _client.get(
+      '/jobs/$jobId',
+      token: token,
+    ) as Map<String, dynamic>;
+
+    return JobModel.fromJson(response);
+  }
+}

--- a/lib/services/podcast_api_service.dart
+++ b/lib/services/podcast_api_service.dart
@@ -1,0 +1,75 @@
+import '../models/podcast_models.dart';
+import 'backend_api_client.dart';
+
+class PodcastApiService {
+  PodcastApiService({BackendApiClient? apiClient})
+      : _client = apiClient ?? BackendApiClient();
+
+  final BackendApiClient _client;
+
+  Future<PodcastModel> createPodcast({
+    required String token,
+    required CreatePodcastRequest request,
+  }) async {
+    final response = await _client.post(
+      '/podcasts',
+      token: token,
+      body: request.toJson(),
+    ) as Map<String, dynamic>;
+
+    return PodcastModel.fromJson(response);
+  }
+
+  Future<List<PodcastModel>> listPodcasts({
+    required String token,
+    int limit = 20,
+    int offset = 0,
+  }) async {
+    final response = await _client.get(
+      '/podcasts',
+      token: token,
+      queryParameters: {
+        'limit': limit,
+        'offset': offset,
+      },
+    ) as List<dynamic>;
+
+    return response
+        .map((dynamic item) => PodcastModel.fromJson(item as Map<String, dynamic>))
+        .toList();
+  }
+
+  Future<PodcastModel> getPodcast({
+    required String token,
+    required String podcastId,
+  }) async {
+    final response = await _client.get(
+      '/podcasts/$podcastId',
+      token: token,
+    ) as Map<String, dynamic>;
+
+    return PodcastModel.fromJson(response);
+  }
+
+  Future<PodcastDetailModel> getPodcastWithScript({
+    required String token,
+    required String podcastId,
+  }) async {
+    final response = await _client.get(
+      '/podcasts/$podcastId/with-script',
+      token: token,
+    ) as Map<String, dynamic>;
+
+    return PodcastDetailModel.fromJson(response);
+  }
+
+  Future<void> deletePodcast({
+    required String token,
+    required String podcastId,
+  }) async {
+    await _client.delete(
+      '/podcasts/$podcastId',
+      token: token,
+    );
+  }
+}

--- a/lib/services/scripts_api_service.dart
+++ b/lib/services/scripts_api_service.dart
@@ -1,0 +1,63 @@
+import '../models/script_models.dart';
+import 'backend_api_client.dart';
+
+class ScriptsApiService {
+  ScriptsApiService({BackendApiClient? apiClient})
+      : _client = apiClient ?? BackendApiClient();
+
+  final BackendApiClient _client;
+
+  Future<ScriptModel> createScript({
+    required String token,
+    required CreateScriptRequest request,
+  }) async {
+    final response = await _client.post(
+      '/scripts',
+      token: token,
+      body: request.toJson(),
+    ) as Map<String, dynamic>;
+
+    return ScriptModel.fromJson(response);
+  }
+
+  Future<List<ScriptModel>> listScripts({
+    required String token,
+    int limit = 20,
+    int offset = 0,
+  }) async {
+    final response = await _client.get(
+      '/scripts',
+      token: token,
+      queryParameters: {
+        'limit': limit,
+        'offset': offset,
+      },
+    ) as List<dynamic>;
+
+    return response
+        .map((dynamic item) => ScriptModel.fromJson(item as Map<String, dynamic>))
+        .toList();
+  }
+
+  Future<ScriptModel> getScript({
+    required String token,
+    required String scriptId,
+  }) async {
+    final response = await _client.get(
+      '/scripts/$scriptId',
+      token: token,
+    ) as Map<String, dynamic>;
+
+    return ScriptModel.fromJson(response);
+  }
+
+  Future<void> deleteScript({
+    required String token,
+    required String scriptId,
+  }) async {
+    await _client.delete(
+      '/scripts/$scriptId',
+      token: token,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- point the default API base URL at the deployed FastAPI instance and introduce a shared HTTP client with consistent error handling
- add typed models and service wrappers for API keys, content, scripts, podcasts, and jobs so the Flutter app can call every backend module

## Testing
- flutter analyze *(fails: Flutter SDK is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d505e8c434832da1c768dcf8f7cbed