### PR TITLE
Fix onboarding submission parsing and async test support

### DIFF
--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -3,7 +3,15 @@ from datetime import UTC, datetime
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, EmailStr, Field, HttpUrl, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    EmailStr,
+    Field,
+    HttpUrl,
+    field_validator,
+    model_validator,
+)
 
 
 class AuthMethod(str, Enum):
@@ -135,6 +143,8 @@ class ProfileUpdateRequest(BaseModel):
 class OnboardingAnswer(BaseModel):
     """Represents a single onboarding question and answer."""
 
+    model_config = ConfigDict(populate_by_name=True)
+
     question_id: str = Field(alias="questionId")
     question: str
     answer: Any
@@ -142,6 +152,8 @@ class OnboardingAnswer(BaseModel):
 
 class OnboardingSubmission(BaseModel):
     """Onboarding payload collected after first sign in."""
+
+    model_config = ConfigDict(populate_by_name=True)
 
     responses: List[OnboardingAnswer]
     completed_at: datetime = Field(default_factory=lambda: datetime.now(UTC))

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,7 +1,12 @@
 """Pytest fixtures and environment configuration."""
+import asyncio
+import inspect
 import os
 import sys
 from pathlib import Path
+from typing import Generator
+
+import pytest
 
 ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
@@ -12,3 +17,41 @@ os.environ.setdefault("SUPABASE_URL", "https://example.supabase.co")
 os.environ.setdefault("SUPABASE_ANON_KEY", "anon-key")
 os.environ.setdefault("SUPABASE_SERVICE_ROLE_KEY", "service-role-key")
 os.environ.setdefault("JWT_SECRET", "test-secret")
+
+
+@pytest.fixture(scope="session")
+def anyio_backend() -> str:
+    """Limit AnyIO-powered tests to the asyncio backend."""
+
+    return "asyncio"
+
+
+@pytest.fixture
+def event_loop() -> Generator[asyncio.AbstractEventLoop, None, None]:
+    """Provide a fresh event loop for tests marked with ``@pytest.mark.asyncio``."""
+
+    loop = asyncio.new_event_loop()
+    try:
+        yield loop
+    finally:
+        loop.close()
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_pyfunc_call(pyfuncitem: pytest.Function) -> bool | None:
+    """Run ``async def`` tests without requiring external plugins."""
+
+    if "anyio_backend" in pyfuncitem.fixturenames:
+        # Let AnyIO's plugin handle parametrised runs.
+        return None
+
+    test_function = pyfuncitem.obj
+    if inspect.iscoroutinefunction(test_function):
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(test_function(**pyfuncitem.funcargs))
+        finally:
+            loop.close()
+        return True
+
+    return None


### PR DESCRIPTION
## Summary
- allow onboarding schemas to populate fields by name so backend accepts both alias and snake_case inputs
- enhance backend test configuration to run asyncio tests without extra plugins and pin AnyIO runs to the asyncio backend

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d50a237814832d8e7fee52aa0d7ff2