### PR TITLE
Handle Supabase onboarding persistence and improve auth flow debugging

### DIFF
--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -111,6 +111,8 @@ class SupabaseAsyncClient:
 
         response = await self._rest_client.post(f"/{table}", json=payload, headers=headers)
         response.raise_for_status()
+        if not response.content:
+            return []
         return response.json()
 
     async def update(
@@ -125,8 +127,12 @@ class SupabaseAsyncClient:
         if options and options.prefer:
             headers["Prefer"] = options.prefer
 
-        response = await self._rest_client.patch(f"/{table}", params=filters or {}, json=payload, headers=headers)
+        response = await self._rest_client.patch(
+            f"/{table}", params=filters or {}, json=payload, headers=headers
+        )
         response.raise_for_status()
+        if not response.content:
+            return []
         return response.json()
 
     async def delete(
@@ -137,6 +143,8 @@ class SupabaseAsyncClient:
     ) -> List[Dict[str, Any]]:
         response = await self._rest_client.delete(f"/{table}", params=filters or {})
         response.raise_for_status()
+        if not response.content:
+            return []
         return response.json()
 
     async def rpc(self, function: str, *, payload: Optional[Dict[str, Any]] = None) -> Any:

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -3,7 +3,15 @@ from datetime import UTC, datetime
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, EmailStr, Field, HttpUrl, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    EmailStr,
+    Field,
+    HttpUrl,
+    field_validator,
+    model_validator,
+)
 
 
 class AuthMethod(str, Enum):
@@ -135,6 +143,8 @@ class ProfileUpdateRequest(BaseModel):
 class OnboardingAnswer(BaseModel):
     """Represents a single onboarding question and answer."""
 
+    model_config = ConfigDict(populate_by_name=True)
+
     question_id: str = Field(alias="questionId")
     question: str
     answer: Any
@@ -142,6 +152,8 @@ class OnboardingAnswer(BaseModel):
 
 class OnboardingSubmission(BaseModel):
     """Onboarding payload collected after first sign in."""
+
+    model_config = ConfigDict(populate_by_name=True)
 
     responses: List[OnboardingAnswer]
     completed_at: datetime = Field(default_factory=lambda: datetime.now(UTC))

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,7 +1,12 @@
 """Pytest fixtures and environment configuration."""
+import asyncio
+import inspect
 import os
 import sys
 from pathlib import Path
+from typing import Generator
+
+import pytest
 
 ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
@@ -12,3 +17,41 @@ os.environ.setdefault("SUPABASE_URL", "https://example.supabase.co")
 os.environ.setdefault("SUPABASE_ANON_KEY", "anon-key")
 os.environ.setdefault("SUPABASE_SERVICE_ROLE_KEY", "service-role-key")
 os.environ.setdefault("JWT_SECRET", "test-secret")
+
+
+@pytest.fixture(scope="session")
+def anyio_backend() -> str:
+    """Limit AnyIO-powered tests to the asyncio backend."""
+
+    return "asyncio"
+
+
+@pytest.fixture
+def event_loop() -> Generator[asyncio.AbstractEventLoop, None, None]:
+    """Provide a fresh event loop for tests marked with ``@pytest.mark.asyncio``."""
+
+    loop = asyncio.new_event_loop()
+    try:
+        yield loop
+    finally:
+        loop.close()
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_pyfunc_call(pyfuncitem: pytest.Function) -> bool | None:
+    """Run ``async def`` tests without requiring external plugins."""
+
+    if "anyio_backend" in pyfuncitem.fixturenames:
+        # Let AnyIO's plugin handle parametrised runs.
+        return None
+
+    test_function = pyfuncitem.obj
+    if inspect.iscoroutinefunction(test_function):
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(test_function(**pyfuncitem.funcargs))
+        finally:
+            loop.close()
+        return True
+
+    return None

--- a/backend/tests/test_database_client.py
+++ b/backend/tests/test_database_client.py
@@ -1,0 +1,68 @@
+"""Tests for the lightweight Supabase client wrapper."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from backend.app.core.config import Settings
+from backend.app.core.database import SupabaseAsyncClient
+
+
+@pytest.fixture()
+def settings() -> Settings:
+    return Settings(
+        supabase_url="https://example.supabase.co",
+        supabase_anon_key="anon-test",
+        supabase_service_role_key="service-test",
+        jwt_secret="secret",
+    )
+
+
+@pytest.mark.anyio
+async def test_update_handles_no_content(settings: Settings) -> None:
+    client = SupabaseAsyncClient(settings)
+    try:
+        response = httpx.Response(
+            204, request=httpx.Request("PATCH", "https://example.supabase.co/rest/v1/profiles")
+        )
+        client._rest_client.patch = AsyncMock(return_value=response)  # type: ignore[attr-defined]
+
+        result = await client.update("profiles", {"full_name": "Test"})
+
+        assert result == []
+    finally:
+        await client.close()
+
+
+@pytest.mark.anyio
+async def test_insert_handles_empty_payload(settings: Settings) -> None:
+    client = SupabaseAsyncClient(settings)
+    try:
+        response = httpx.Response(
+            201, request=httpx.Request("POST", "https://example.supabase.co/rest/v1/onboarding_responses")
+        )
+        client._rest_client.post = AsyncMock(return_value=response)  # type: ignore[attr-defined]
+
+        result = await client.insert("onboarding_responses", {"user_id": "123"})
+
+        assert result == []
+    finally:
+        await client.close()
+
+
+@pytest.mark.anyio
+async def test_delete_handles_no_content(settings: Settings) -> None:
+    client = SupabaseAsyncClient(settings)
+    try:
+        response = httpx.Response(
+            204, request=httpx.Request("DELETE", "https://example.supabase.co/rest/v1/profiles")
+        )
+        client._rest_client.delete = AsyncMock(return_value=response)  # type: ignore[attr-defined]
+
+        result = await client.delete("profiles", filters={"id": "eq.123"})
+
+        assert result == []
+    finally:
+        await client.close()

--- a/lib/screens/auth/auth_flow_screen.dart
+++ b/lib/screens/auth/auth_flow_screen.dart
@@ -6,7 +6,6 @@ import '../../models/auth_models.dart';
 import '../../providers/auth_provider.dart';
 import '../home_screen.dart';
 import '../user_onboarding_screen.dart';
-import 'verification_screen.dart';
 
 enum _CredentialType { email, phone }
 
@@ -89,9 +88,6 @@ class _AuthFlowScreenState extends State<AuthFlowScreen>
         remember: _rememberMe,
       );
       if (!mounted) return;
-      await Navigator.of(context).push(MaterialPageRoute(
-        builder: (_) => VerificationScreen(email: email),
-      ));
       await _navigatePostAuth(context, authProvider);
     } on ApiException catch (error) {
       _showError(context, error.message);

--- a/lib/utils/debug_logger.dart
+++ b/lib/utils/debug_logger.dart
@@ -1,0 +1,28 @@
+import 'dart:developer' as developer;
+
+import 'package:flutter/foundation.dart';
+
+/// Lightweight logging utility that surfaces structured debugging output
+/// without polluting release builds.
+class DebugLogger {
+  const DebugLogger._();
+
+  /// Emit a debug level log with an optional [category] label.
+  static void log(
+    String message, {
+    String category = 'EchoGen',
+    Object? error,
+    StackTrace? stackTrace,
+  }) {
+    if (kDebugMode) {
+      developer.log(
+        message,
+        name: category,
+        error: error,
+        stackTrace: stackTrace,
+      );
+    } else if (error != null) {
+      debugPrint('[$category] $message: $error');
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- guard Supabase insert/update/delete helpers against empty response bodies so onboarding updates no longer raise JSON decode errors
- add coverage for the Supabase client to ensure 204/201 responses return empty payloads safely
- introduce a reusable debug logger, instrument auth provider flows, and skip the OTP detour after sign up so users proceed straight to onboarding

## Testing
- pytest backend/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68d50a237814832d8e7fee52aa0d7ff2