### PR TITLE
Refine auth layout and add onboarding skip option

### DIFF
--- a/lib/providers/auth_provider.dart
+++ b/lib/providers/auth_provider.dart
@@ -179,6 +179,18 @@ class AuthProvider extends ChangeNotifier {
     return updated;
   }
 
+  Future<void> skipOnboarding() async {
+    DebugLogger.log(
+      'Skipping onboarding at user request',
+      category: 'AuthProvider',
+    );
+    _status = AuthStatus.authenticated;
+    if (_user != null) {
+      _user = _user!.copyWith(onboardingCompleted: true);
+    }
+    notifyListeners();
+  }
+
   Future<AccountDeletionStatusModel> scheduleAccountDeletion() async {
     final token = _requireToken();
     final statusModel = await _apiService.scheduleAccountDeletion(token);

--- a/lib/screens/auth/auth_flow_screen.dart
+++ b/lib/screens/auth/auth_flow_screen.dart
@@ -143,66 +143,56 @@ class _AuthFlowScreenState extends State<AuthFlowScreen>
     return Theme(
       data: AppTheme.lightTheme,
       child: Scaffold(
-      backgroundColor: AppTheme.background,
-      body: SafeArea(
-        child: LayoutBuilder(
-          builder: (context, constraints) {
-            final isWide = constraints.maxWidth > 640;
-            final cardWidth = isWide ? 520.0 : constraints.maxWidth * 0.92;
+        backgroundColor: AppTheme.background,
+        body: SafeArea(
+          child: LayoutBuilder(
+            builder: (context, constraints) {
+              final isWide = constraints.maxWidth > 640;
+              final horizontalPadding = isWide ? 64.0 : 24.0;
 
-            return SingleChildScrollView(
-              padding: EdgeInsets.symmetric(
-                horizontal: isWide ? 48 : 24,
-                vertical: isWide ? 48 : 24,
-              ),
-              child: Center(
-                child: AnimatedContainer(
-                  duration: const Duration(milliseconds: 400),
-                  curve: Curves.easeInOut,
-                  width: cardWidth,
-                  decoration: BoxDecoration(
-                    color: AppTheme.surface,
-                    borderRadius: BorderRadius.circular(32),
-                    boxShadow: [
-                      BoxShadow(
-                        color: AppTheme.primaryBlue.withOpacity(0.08),
-                        blurRadius: 32,
-                        offset: const Offset(0, 24),
+              return SingleChildScrollView(
+                padding: EdgeInsets.symmetric(
+                  horizontal: horizontalPadding,
+                  vertical: isWide ? 64 : 32,
+                ),
+                child: Align(
+                  alignment: Alignment.topCenter,
+                  child: ConstrainedBox(
+                    constraints: BoxConstraints(
+                      maxWidth: isWide ? 560 : double.infinity,
+                    ),
+                    child: AnimatedSize(
+                      duration: const Duration(milliseconds: 250),
+                      curve: Curves.easeInOut,
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          _buildHeader(),
+                          const SizedBox(height: 24),
+                          _buildModeSwitcher(),
+                          const SizedBox(height: 24),
+                          AnimatedSwitcher(
+                            duration: const Duration(milliseconds: 300),
+                            switchInCurve: Curves.easeOut,
+                            switchOutCurve: Curves.easeIn,
+                            child: _mode == _AuthMode.signIn
+                                ? _buildSignInForm(context, authProvider)
+                                : _buildSignUpForm(context, authProvider),
+                          ),
+                          const SizedBox(height: 24),
+                          _buildSocialLogins(),
+                        ],
                       ),
-                    ],
-                  ),
-                  padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 32),
-                  child: AnimatedSize(
-                    duration: const Duration(milliseconds: 250),
-                    curve: Curves.easeInOut,
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        _buildHeader(),
-                        const SizedBox(height: 24),
-                        _buildModeSwitcher(),
-                        const SizedBox(height: 24),
-                        AnimatedSwitcher(
-                          duration: const Duration(milliseconds: 300),
-                          switchInCurve: Curves.easeOut,
-                          switchOutCurve: Curves.easeIn,
-                          child: _mode == _AuthMode.signIn
-                              ? _buildSignInForm(context, authProvider)
-                              : _buildSignUpForm(context, authProvider),
-                        ),
-                        const SizedBox(height: 24),
-                        _buildSocialLogins(),
-                      ],
                     ),
                   ),
                 ),
-              ),
-            );
-          },
+              );
+            },
+          ),
         ),
       ),
-    ));
+    );
   }
 
   Widget _buildHeader() {

--- a/lib/screens/user_onboarding_screen.dart
+++ b/lib/screens/user_onboarding_screen.dart
@@ -107,6 +107,16 @@ class _UserOnboardingScreenState extends State<UserOnboardingScreen> {
     }
   }
 
+  Future<void> _skipOnboarding() async {
+    final authProvider = context.read<AuthProvider>();
+    await authProvider.skipOnboarding();
+    if (!mounted) return;
+    Navigator.of(context).pushAndRemoveUntil(
+      MaterialPageRoute(builder: (_) => const HomeScreen()),
+      (_) => false,
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -193,6 +203,13 @@ class _UserOnboardingScreenState extends State<UserOnboardingScreen> {
                         : Text(_currentPage == _questions.length - 1 ? 'Finish' : 'Next'),
                   ),
                 ],
+              ),
+              const SizedBox(height: 16),
+              Center(
+                child: TextButton(
+                  onPressed: _isSubmitting ? null : _skipOnboarding,
+                  child: const Text('Skip for now'),
+                ),
               ),
             ],
           ),


### PR DESCRIPTION
## Summary
- remove the card-style container on the auth flow so login and sign-up elements sit directly on the page
- add an onboarding skip path in the provider and surface a "Skip for now" button on the onboarding screen to reach the home page if submission fails

## Testing
- not run (Flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e35d05840c832db67d46b66caf8a02