### PR TITLE
Improve API key service resilience

### DIFF
--- a/backend/app/services/api_key_service.py
+++ b/backend/app/services/api_key_service.py
@@ -1,14 +1,18 @@
 """Service for securely storing provider API keys."""
 from __future__ import annotations
 
-from typing import List
+import logging
+from typing import Any, Dict, Iterable, List, Optional
 
+import httpx
 from fastapi import HTTPException, status
 
 from ..core.database import SupabaseAsyncClient
 from ..schemas.apikey import APIKeyCreate, APIKeyResponse, APIKeyUpdate
 
 USER_API_KEYS_TABLE = "user_api_keys"
+
+logger = logging.getLogger(__name__)
 
 
 class APIKeyService:
@@ -23,26 +27,120 @@ class APIKeyService:
             "encrypted_key": payload.encrypted_key,
             "metadata": payload.metadata,
         }
-        response = await self._client.insert(USER_API_KEYS_TABLE, record)
-        return self._parse(response)[0]
+        try:
+            response = await self._client.insert(USER_API_KEYS_TABLE, record)
+        except httpx.HTTPError as exc:  # pragma: no cover - exercised via helper
+            self._handle_http_error(exc, "Failed to save API key")
+
+        parsed = self._parse(response)
+        if not parsed:
+            logger.error(
+                "Supabase insert returned empty payload for API key",
+                extra={"user_id": user_id, "provider": payload.provider},
+            )
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail="Unable to persist API key. Please try again.",
+            )
+        return parsed[0]
 
     async def list_api_keys(self, user_id: str) -> List[APIKeyResponse]:
-        response = await self._client.select(USER_API_KEYS_TABLE, filters={"user_id": f"eq.{user_id}"})
+        try:
+            response = await self._client.select(
+                USER_API_KEYS_TABLE, filters={"user_id": f"eq.{user_id}"}
+            )
+        except httpx.HTTPError as exc:  # pragma: no cover - exercised via helper
+            self._handle_http_error(exc, "Failed to load API keys")
         return self._parse(response)
 
     async def update_api_key(self, user_id: str, key_id: str, payload: APIKeyUpdate) -> APIKeyResponse:
-        response = await self._client.update(
-            USER_API_KEYS_TABLE,
-            payload.model_dump(exclude_none=True),
-            filters={"id": f"eq.{key_id}", "user_id": f"eq.{user_id}"},
-        )
+        update_payload = payload.model_dump(exclude_none=True)
+        if not update_payload:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="No fields provided for update",
+            )
+
+        try:
+            response = await self._client.update(
+                USER_API_KEYS_TABLE,
+                update_payload,
+                filters={"id": f"eq.{key_id}", "user_id": f"eq.{user_id}"},
+            )
+        except httpx.HTTPError as exc:  # pragma: no cover - exercised via helper
+            self._handle_http_error(exc, "Failed to update API key")
+
         parsed = self._parse(response)
         if not parsed:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="API key not found")
         return parsed[0]
 
     async def delete_api_key(self, user_id: str, key_id: str) -> None:
-        await self._client.delete(USER_API_KEYS_TABLE, filters={"id": f"eq.{key_id}", "user_id": f"eq.{user_id}"})
+        try:
+            await self._client.delete(
+                USER_API_KEYS_TABLE, filters={"id": f"eq.{key_id}", "user_id": f"eq.{user_id}"}
+            )
+        except httpx.HTTPError as exc:  # pragma: no cover - exercised via helper
+            self._handle_http_error(exc, "Failed to delete API key")
 
-    def _parse(self, data) -> List[APIKeyResponse]:
-        return [APIKeyResponse(**item) for item in data]
+    def _parse(self, data: Optional[Iterable[Dict[str, Any]]]) -> List[APIKeyResponse]:
+        records: List[APIKeyResponse] = []
+        if not data:
+            return records
+
+        for item in data:
+            try:
+                record = {
+                    "id": item["id"],
+                    "provider": item["provider"],
+                    "key_alias": item.get("key_alias"),
+                    "metadata": item.get("metadata") or {},
+                    "created_at": item["created_at"],
+                    "updated_at": item["updated_at"],
+                }
+            except KeyError as exc:  # pragma: no cover - defensive guard
+                logger.warning(
+                    "Incomplete API key record received",
+                    extra={"record": item},
+                    exc_info=True,
+                )
+                continue
+            records.append(APIKeyResponse(**record))
+        return records
+
+    def _handle_http_error(self, exc: httpx.HTTPError, fallback_detail: str) -> None:
+        if isinstance(exc, httpx.HTTPStatusError):
+            detail = self._extract_error_detail(exc.response) or fallback_detail
+            raise HTTPException(status_code=exc.response.status_code, detail=detail) from exc
+
+        logger.error("Supabase request failed: %s", exc)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=fallback_detail,
+        ) from exc
+
+    @staticmethod
+    def _extract_error_detail(response: httpx.Response) -> Optional[str]:
+        try:
+            payload = response.json()
+        except ValueError:  # pragma: no cover - non JSON payloads are rare
+            text = response.text.strip()
+            return text or None
+
+        if isinstance(payload, dict):
+            candidates: List[Any] = [
+                payload.get("detail"),
+                payload.get("message"),
+                payload.get("msg"),
+                payload.get("error_description"),
+                payload.get("error"),
+            ]
+            for candidate in candidates:
+                if isinstance(candidate, str) and candidate:
+                    return candidate
+                if isinstance(candidate, dict):
+                    nested = candidate.get("message")
+                    if isinstance(nested, str) and nested:
+                        return nested
+
+        return None

--- a/backend/tests/test_api_key_service.py
+++ b/backend/tests/test_api_key_service.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+from fastapi import HTTPException, status
+
+from backend.app.schemas.apikey import APIKeyCreate, APIKeyUpdate
+from backend.app.services.api_key_service import APIKeyService, USER_API_KEYS_TABLE
+
+
+class FakeSupabaseClient:
+    def __init__(self) -> None:
+        self.insert = AsyncMock()
+        self.select = AsyncMock()
+        self.update = AsyncMock()
+        self.delete = AsyncMock()
+
+
+def build_db_record(**overrides: Any) -> Dict[str, Any]:
+    base: Dict[str, Any] = {
+        "id": "key-123",
+        "user_id": "user-1",
+        "provider": "openai",
+        "key_alias": "Primary",
+        "metadata": {"status": "valid"},
+        "created_at": "2024-01-01T00:00:00Z",
+        "updated_at": "2024-01-01T00:00:00Z",
+    }
+    base.update(overrides)
+    return base
+
+
+def make_http_status_error(status_code: int, payload: Dict[str, Any]) -> httpx.HTTPStatusError:
+    request = httpx.Request("POST", "https://example.supabase.co/rest/v1/user_api_keys")
+    response = httpx.Response(status_code, json=payload, request=request)
+    return httpx.HTTPStatusError("error", request=request, response=response)
+
+
+@pytest.mark.anyio
+async def test_create_api_key_persists_and_returns_record() -> None:
+    client = FakeSupabaseClient()
+    service = APIKeyService(client)
+
+    payload = APIKeyCreate(provider="openai", key_alias="Primary", encrypted_key="cipher", metadata={"status": "valid"})
+    db_response: List[Dict[str, Any]] = [build_db_record()]
+    client.insert.return_value = db_response
+
+    result = await service.create_api_key("user-1", payload)
+
+    client.insert.assert_awaited_once_with(
+        USER_API_KEYS_TABLE,
+        {
+            "user_id": "user-1",
+            "provider": "openai",
+            "key_alias": "Primary",
+            "encrypted_key": "cipher",
+            "metadata": {"status": "valid"},
+        },
+    )
+    assert result.id == "key-123"
+    assert result.provider == "openai"
+    assert result.metadata == {"status": "valid"}
+
+
+@pytest.mark.anyio
+async def test_create_api_key_surfaces_supabase_error() -> None:
+    client = FakeSupabaseClient()
+    service = APIKeyService(client)
+
+    payload = APIKeyCreate(provider="openai", key_alias=None, encrypted_key="cipher", metadata={})
+    client.insert.side_effect = make_http_status_error(status.HTTP_409_CONFLICT, {"message": "duplicate"})
+
+    with pytest.raises(HTTPException) as exc:
+        await service.create_api_key("user-1", payload)
+
+    assert exc.value.status_code == status.HTTP_409_CONFLICT
+    assert exc.value.detail == "duplicate"
+
+
+@pytest.mark.anyio
+async def test_create_api_key_handles_transport_error() -> None:
+    client = FakeSupabaseClient()
+    service = APIKeyService(client)
+
+    payload = APIKeyCreate(provider="openai", key_alias=None, encrypted_key="cipher", metadata={})
+    client.insert.side_effect = httpx.TransportError("boom")
+
+    with pytest.raises(HTTPException) as exc:
+        await service.create_api_key("user-1", payload)
+
+    assert exc.value.status_code == status.HTTP_502_BAD_GATEWAY
+    assert exc.value.detail == "Failed to save API key"
+
+
+@pytest.mark.anyio
+async def test_create_api_key_with_empty_response_raises_gateway_error() -> None:
+    client = FakeSupabaseClient()
+    service = APIKeyService(client)
+
+    payload = APIKeyCreate(provider="openai", key_alias=None, encrypted_key="cipher", metadata={})
+    client.insert.return_value = []
+
+    with pytest.raises(HTTPException) as exc:
+        await service.create_api_key("user-1", payload)
+
+    assert exc.value.status_code == status.HTTP_502_BAD_GATEWAY
+    assert "Unable to persist API key" in exc.value.detail
+
+
+@pytest.mark.anyio
+async def test_list_api_keys_returns_parsed_models() -> None:
+    client = FakeSupabaseClient()
+    service = APIKeyService(client)
+
+    client.select.return_value = [build_db_record(), build_db_record(id="key-456", provider="gemini")]
+
+    results = await service.list_api_keys("user-1")
+
+    client.select.assert_awaited_once_with(USER_API_KEYS_TABLE, filters={"user_id": "eq.user-1"})
+    assert [item.id for item in results] == ["key-123", "key-456"]
+
+
+@pytest.mark.anyio
+async def test_list_api_keys_surfaces_http_error() -> None:
+    client = FakeSupabaseClient()
+    service = APIKeyService(client)
+
+    client.select.side_effect = make_http_status_error(status.HTTP_500_INTERNAL_SERVER_ERROR, {"message": "broken"})
+
+    with pytest.raises(HTTPException) as exc:
+        await service.list_api_keys("user-1")
+
+    assert exc.value.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    assert exc.value.detail == "broken"
+
+
+@pytest.mark.anyio
+async def test_update_api_key_requires_payload() -> None:
+    client = FakeSupabaseClient()
+    service = APIKeyService(client)
+
+    with pytest.raises(HTTPException) as exc:
+        await service.update_api_key("user-1", "key-123", APIKeyUpdate())
+
+    assert exc.value.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.anyio
+async def test_update_api_key_returns_updated_record() -> None:
+    client = FakeSupabaseClient()
+    service = APIKeyService(client)
+
+    client.update.return_value = [build_db_record(key_alias="Updated")]
+
+    result = await service.update_api_key("user-1", "key-123", APIKeyUpdate(key_alias="Updated"))
+
+    client.update.assert_awaited_once_with(
+        USER_API_KEYS_TABLE,
+        {"key_alias": "Updated"},
+        filters={"id": "eq.key-123", "user_id": "eq.user-1"},
+    )
+    assert result.key_alias == "Updated"
+
+
+@pytest.mark.anyio
+async def test_update_api_key_not_found() -> None:
+    client = FakeSupabaseClient()
+    service = APIKeyService(client)
+
+    client.update.return_value = []
+
+    with pytest.raises(HTTPException) as exc:
+        await service.update_api_key("user-1", "key-123", APIKeyUpdate(key_alias="Updated"))
+
+    assert exc.value.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.anyio
+async def test_delete_api_key_invokes_supabase() -> None:
+    client = FakeSupabaseClient()
+    service = APIKeyService(client)
+
+    await service.delete_api_key("user-1", "key-123")
+
+    client.delete.assert_awaited_once_with(
+        USER_API_KEYS_TABLE,
+        filters={"id": "eq.key-123", "user_id": "eq.user-1"},
+    )
+
+
+@pytest.mark.anyio
+async def test_delete_api_key_surfaces_error() -> None:
+    client = FakeSupabaseClient()
+    service = APIKeyService(client)
+
+    client.delete.side_effect = make_http_status_error(status.HTTP_400_BAD_REQUEST, {"message": "bad"})
+
+    with pytest.raises(HTTPException) as exc:
+        await service.delete_api_key("user-1", "key-123")
+
+    assert exc.value.status_code == status.HTTP_400_BAD_REQUEST
+    assert exc.value.detail == "bad"


### PR DESCRIPTION
## Summary
- add defensive error handling to the API key service for create, list, update, and delete flows
- normalize Supabase payload parsing to ensure consistent metadata handling
- introduce unit tests that exercise happy-path and error scenarios for API key management

## Testing
- pytest backend/tests/test_api_key_service.py

------
https://chatgpt.com/codex/tasks/task_e_68e370f9b75c832da66b8cc8fb0b92b0